### PR TITLE
Adding textType option for SSML

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ class PollyTTS {
     }
     let qs = {
       Text: options.text,
-      TextType: "text",
+      TextType: options.textType || "text",
       VoiceId: options.voiceId || "Vicki",
       SampleRate: options.sampleRate || 22050,
       OutputFormat: options.outputFormat || "mp3"


### PR DESCRIPTION
This enabled specifying SSML input instead of plaintext with the hardcoded `text` value for TextType.

Use: specify `... textType: "ssml" ...` in the options object when using `polly.textToSpeech()`.